### PR TITLE
Re-expose hardcoded white text colors

### DIFF
--- a/res/layout/crypt_keeper_emergency_button.xml
+++ b/res/layout/crypt_keeper_emergency_button.xml
@@ -33,7 +33,7 @@
         android:layout_gravity="center_horizontal"
         android:textSize="14sp"
         android:fontFamily="sans-serif"
-        android:textColor="@color/text_color_white"
+        android:textColor="@color/crypt_keeper_emergency_button_text_color"
         style="?android:attr/borderlessButtonStyle" />
 
 </LinearLayout>

--- a/res/layout/crypt_keeper_pattern_sizes.xml
+++ b/res/layout/crypt_keeper_pattern_sizes.xml
@@ -24,7 +24,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_3"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/crypt_keeper_lock_pattern_text_color"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -36,7 +36,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_4"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/crypt_keeper_lock_pattern_text_color"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -48,7 +48,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_5"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/crypt_keeper_lock_pattern_text_color"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -60,7 +60,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_6"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/crypt_keeper_lock_pattern_text_color"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 

--- a/res/layout/crypt_keeper_status.xml
+++ b/res/layout/crypt_keeper_status.xml
@@ -35,7 +35,7 @@
         android:layout_marginEnd="8dip"
         android:textSize="16sp"
         android:fontFamily="sans-serif"
-        android:textColor="@color/text_color_white"
+        android:textColor="@color/crypt_keeper_status_text_color"
         android:text="@string/enter_password"
         android:layout_gravity="center_horizontal"
         android:gravity="center_horizontal" />

--- a/res/layout/custom_screencolor.xml
+++ b/res/layout/custom_screencolor.xml
@@ -46,7 +46,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_gravity="center_vertical"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/custom_screencolor_buttons_text_color"
             android:text="@string/screencolor_cancel"
             android:background="@drawable/screencolor_btn"/>
         <Button
@@ -55,7 +55,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_gravity="center_vertical"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/custom_screencolor_buttons_text_color"
             android:text="@string/screencolor_save"
             android:background="@drawable/screencolor_btn"/>
     </LinearLayout>
@@ -126,7 +126,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 android:paddingLeft="20dip"
                 android:paddingTop="10dip"
                 android:layout_width="match_parent"
-                android:textColor="@color/text_color_white"
+                android:textColor="@color/custom_screencolor_buttons_text_color"
                 android:text="@string/hue_str"/>
 
             <RelativeLayout
@@ -168,7 +168,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 android:paddingLeft="20dip"
                 android:paddingTop="10dip"
                 android:layout_width="fill_parent"
-                android:textColor="@color/text_color_white"
+                android:textColor="@color/custom_screencolor_buttons_text_color"
                 android:text="@string/saturation_str"/>
             <RelativeLayout
                 android:layout_width="wrap_content"
@@ -207,7 +207,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 android:paddingLeft="20dip"
                 android:paddingTop="10dip"
                 android:layout_width="fill_parent"
-                android:textColor="@color/text_color_white"
+                android:textColor="@color/custom_screencolor_buttons_text_color"
                 android:text="@string/contrast_str"/>
             <RelativeLayout
                 android:layout_width="wrap_content"
@@ -246,7 +246,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 android:paddingLeft="20dip"
                 android:paddingTop="10dip"
                 android:layout_width="fill_parent"
-                android:textColor="@color/text_color_white"
+                android:textColor="@color/custom_screencolor_buttons_text_color"
                 android:text="@string/intensity_str"/>
             <RelativeLayout
                 android:layout_width="wrap_content"

--- a/res/layout/privacy_guard_manager.xml
+++ b/res/layout/privacy_guard_manager.xml
@@ -33,7 +33,7 @@
         android:layout_marginTop="20dip"
         android:layout_gravity="center"
         android:gravity="center_horizontal"
-        android:textColor="@color/text_color_white"
+        android:textColor="@color/privacy_guard_error_text_color"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:visibility="gone" />
     <FrameLayout

--- a/res/layout/screen_color_item.xml
+++ b/res/layout/screen_color_item.xml
@@ -55,7 +55,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             android:singleLine="true"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textAlignment="viewStart"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/screen_color_button_text_color"
             android:labelFor="@android:id/button2" />
 
         <RadioButton

--- a/res/layout/storage_internal_format.xml
+++ b/res/layout/storage_internal_format.xml
@@ -46,7 +46,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/storage_menu_format"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/storage_wizard_red_button_text_color"
             android:backgroundTint="@color/storage_wizard_button_red" />
     </FrameLayout>
 

--- a/res/layout/storage_wizard_navigation.xml
+++ b/res/layout/storage_wizard_navigation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2015 The Android Open Source Project
+<!-- Copyright (C) 2016 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@
         android:layout_marginBottom="16dp"
         android:layout_marginEnd="16dp"
         android:text="@string/wizard_next"
-        android:textColor="@color/text_color_white"
+        android:textColor="@color/storage_wizard_button_text_color"
         android:backgroundTint="@color/storage_wizard_button" />
 
 </LinearLayout>

--- a/res/values/cm_colors.xml
+++ b/res/values/cm_colors.xml
@@ -117,4 +117,14 @@ limitations under the License.
     <!-- Power Usage Hard colors-->
 
     <color name="power_usage_ab_icon_tint">@android:color/white</color>
+
+    <color name="storage_wizard_button_text_color">@color/text_color_white</color>
+    <color name="storage_wizard_red_button_text_color">@color/text_color_white</color>
+    <color name="screen_color_button_text_color">@color/text_color_white</color>
+    <color name="privacy_guard_error_text_color">@color/text_color_white</color>
+    <color name="crypt_keeper_status_text_color">@color/text_color_white</color>
+    <color name="crypt_keeper_lock_pattern_text_color">@color/text_color_white</color>
+    <color name="crypt_keeper_emergency_button_text_color">@color/text_color_white</color>
+    <color name="custom_screencolor_buttons_text_color">@color/text_color_white</color>
+
 </resources>


### PR DESCRIPTION
In the original expose pass, all of the hardcoded white text colors
were given a generic color that they all pointed to. This is great,
but very inflexible for themes that might need to tweak just one
of those instances.

With this patch, we will create new text colors (and allow some
textviews to share it when it makes sense) and point all of those
back to the text_color_white so that existing themes are not
broken.

Change-Id: Iae850b7f75d319bd308f001058918e4466c70dca
