### PR TITLE
Settings: Always set text value in color temperature

### DIFF
--- a/src/com/android/settings/livedisplay/DisplayTemperature.java
+++ b/src/com/android/settings/livedisplay/DisplayTemperature.java
@@ -244,6 +244,10 @@ public class DisplayTemperature extends DialogPreference {
             }
             mSeekBar.setMax(mBarMax);
             mSeekBar.setOnSeekBarChangeListener(this);
+
+            // init text value
+            int p = mSeekBar.getProgress();
+            onProgressChanged(mSeekBar, p, false);
         }
 
         @Override


### PR DESCRIPTION
onProgressChange is not always called if we set the
color temperature to minimum, since it is the default
value (no change).
Causing the text showing the color temperature is empty.

Call onProgressChange explicitly during init.

FEIJ-1581

Change-Id: I7e0f8995cfc62a53770e787dc649109b9c3bf189
