### PR TITLE
Settings: Apn: Don't dereference a null mSubscriptionInfo

### DIFF
--- a/src/com/android/settings/ApnSettings.java
+++ b/src/com/android/settings/ApnSettings.java
@@ -430,7 +430,8 @@ public class ApnSettings extends SettingsPreferenceFragment implements
         String key = null;
 
         Uri uri;
-        if (TelephonyManager.getDefault().getPhoneCount() > 1 && mImsi != null)  {
+        if (TelephonyManager.getDefault().getPhoneCount() > 1 && mImsi != null
+                && mSubscriptionInfo != null)  {
             uri = Uri.withAppendedPath(PREFERRED_MSIM_APN_URI,
                     String.valueOf(mSubscriptionInfo.getSubscriptionId()));
             uri = Uri.withAppendedPath(uri, mImsi);


### PR DESCRIPTION
When switching sims mSubscriptionInfo can be temporarily null, don't
dereference it in those cases. The interface will be updated afterwards
when the subscription status changes.

Change-Id: I1011a10434fad8fd911164217b9fb2d0dfb82b2a
Ticket: CYNGNOS-3291
